### PR TITLE
Make Original Source's `column` relative

### DIFF
--- a/proposals/scopes.md
+++ b/proposals/scopes.md
@@ -192,7 +192,7 @@ Note: Each DATA represents one VLQ number.
 * DATA line in the original code
   * Note: this is the point in the original code where the scope starts. `line` is relative to the `line` of the preceding "start/end original scope" item.
 * DATA column in the original code
-  * Note: Column is always absolute.
+  * Note: this is the point in the original code where the scope starts. `column` is relative to the `column` of the preceding "start/end original scope" item.
 * DATA kind
   * Note: This is type of the scope.
   * 0x1 toplevel
@@ -218,7 +218,7 @@ Note: Each DATA represents one VLQ number.
 * DATA line in the original code
   * Note: `line` is relative to the `line` of the preceding "start/end original scope" item.
 * DATA column in the original code
-  * Note: Column is always absolute.
+  * Note: `column` is relative to the `column` of the preceding "start/end original scope" item.
 
 #### Start Generated Range
 


### PR DESCRIPTION
Take the following code:

```js
function foo() {
    function bar() {
        function baz() {
            function qux() {
                function example() {
                }
            }
        }
    }
}
```

This would have scopes:

```js
[ 
  {
    start: { line: 0, column: 0 },
    end: { line: 9, column: 1 },
  },
  {
    start: { line: 1, column: 4 },
    end: { line: 8, column: 5 },
  },
  {
    start: { line: 2, column: 8 },
    end: { line: 7, column: 9 },
  },
  {
    start: { line: 3, column: 12 },
    end: { line: 6, column: 13 },
  },
  {
    start: { line: 4, column: 16 },
    end: { line: 5, column: 17 },
  },
]
```

The absolute columns that we need to encode would give us: `[0, 4, 8, 12, 16, 17, 13, 9, 5, 1]`. As VLQ, we have `A,I,Q,Y,gB,iB,a,S,K,C`. Notice the `gB` and `iB` 2-byte VLQ encodings for `16` and `17` columns. Because VLQ can only use 5 bits of every byte, and the first byte also needs to encode the sign, we only have 4 bits of data to encode the absolute column.

While unlikely to really happen, there's a **easy** alternative that can use 1 byte for all of these: relative encodings, just like `line`. That would mean we just need to encode `[0, 4, 4, 4, 4, 1, -4, -4, -4, -4]`, or `A,I,I,I,I,C,J,J,J,J`.