### PR TITLE
Scopes: Introduce EmptyItem with tag 'A' to signal nil scope info

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -1328,7 +1328,10 @@
 
         OriginalScopeTreeItem :
           OriginalScopeTree
-          [empty]
+          EmptyItem
+
+        EmptyItem :
+          `A`
 
         TopLevelItemList :
           TopLevelItem
@@ -1559,7 +1562,7 @@
             Tag UnknownVlqList
 
           Tag :
-            Vlq but not `B` `C` `D` `E` `F` `G` `H` `I`
+            Vlq but not `A` `B` `C` `D` `E` `F` `G` `H` `I`
 
           UnknownVlqList :
             Vlq
@@ -1800,7 +1803,7 @@
           1. Return the DecodedOriginalScopeTrees of |OriginalScopeTree| with arguments _state_ and _names_.
         </emu-alg>
         <emu-grammar>
-          OriginalScopeTreeItem : [empty]
+          OriginalScopeTreeItem : EmptyItem
         </emu-grammar>
         <emu-alg>
           1. Return « *null* ».


### PR DESCRIPTION
We agreed in the TG4 meeting of 2025-08-28 that we'll replace the empty `OriginalScopeTreeItem` production with an actual "empty tag" to signal that a source map does not provide scope information for a particular `"sources"` file.