### PR TITLE
Add convention around asserts and make it clear that grammars are con…

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -235,6 +235,13 @@
 
       <p>An implementation can choose different behaviours for different optional errors.</p>
     </emu-clause>
+
+    <emu-clause id="sec-assertions-as-optional-errors">
+      <h1>Assertions</h1>
+
+      <p>Similar to ECMA-262's <a href="https://tc39.es/ecma262/#assert">assert</a>, a step that begins with <em>"Assert:"</em> asserts an invariant condition of its algorithm. For an algorithm describing steps to decode the source map format, an <em>"Assert:"</em> may assert invariants of the format itself.</p>
+      <p>An implementation may choose to implement such assertions by rewriting a step <em>Assert: _condition_</em> as <em>If not _condition_, optionally report an error.</em> to be able to decode malformed source maps.</p>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-grammar-notation">
@@ -243,6 +250,7 @@
     <ul>
       <li>The terminal symbols of grammars defined in this specification are individual code points. This is similar to ECMA-262's <a href="https://tc39.es/ecma262/#sec-lexical-and-regexp-grammars">lexical grammar</a>, rather than to ECMA-262's <a href="https://tc39.es/ecma262/#sec-syntactic-grammar">syntactic grammar</a>.</li>
       <li>This specification does not use <a href="https://tc39.es/ecma262/#sec-grammatical-parameters">grammatical parameters</a> or <a href="https://tc39.es/ecma262/#sec-lookahead-restrictions">lookahead restrictions</a>, to reduce the grammar definitions complexity.</li>
+      <li>This specification describes a wire format and not a programming language. The grammars defined in this specification are <em>context-sensitive</em> (i.e. not context-free).</li>
     </ul>
   </emu-clause>
 </emu-clause>


### PR DESCRIPTION
…text-sensitive.

While working on the proposal-scopes branch and the decoding of scope information, I was contemplating how we could keep the algorithms somewhat readable while also accounting for malformed source maps without having to sprinkle "if condition, optionally report an error" everywhere.

As such I suggest the following:
  * We keep the grammar simple and context-sensitive
  * We liberally use asserts to express invariant in the format
  * Decoders may rewrite asserts as "optionally report an error".

As an example, I'd find the former much easier to read then the latter:

```html
<emu-grammar>
  OriginalScopeStart :
    `B` ScopeFlags ScopeLine ScopeColumn ScopeName? ScopeKind?
</emu-grammar>
<emu-alg>
  1. Let _flags_ be the VLQUnsignedValue of |ScopeFlags|.
  1. Assert: _flags_ & 0x2 = 0x2 iff, |ScopeKind| is present.
  1. Return RelativeName(|ScopeKind|, _accumulator_, _names_).
</emu-alg>
```

versus

```html
<emu-grammar>
  OriginalScopeStart :
    `B` ScopeFlags ScopeLine ScopeColumn ScopeNameOrKind? ScopeKind?
</emu-grammar>
<emu-alg>
  1. Let _flags_ be the VLQUnsignedValue of |ScopeFlags|.
  1. If _flags_ & 0x2 ≠ 0x2, return *null*.
  1. If |ScopeNameOrKind| is not present, then
    1. optionally report an error.
    1. return *null*.
  1. If _flags_ & 0x1 = 0x1, then
    1. If |ScopeKind| is not present, then
      1. optionally report an error.
      1. return *null*.
    1. Return RelativeName(|ScopeKind|, _accumulator_, _names_).
  1. Return RelativeName(|ScopeNameOrKind|, _accumulator_, _names_).
</emu-alg>
```

IMO we are specifying a wire format and not a programming language. I eluded to this in the scopes meeting that we shouldn't tailor the specification text so an engineer can follow it line-by-line and implement it, but rather to convey how the format works.

Just a proposal though. If folks feel strongly about keeping it as-is and trying to spell out how to handle the context-sensitive aspects of the grammar in the decoding steps, then we can do that as well :)