### PR TITLE
Range mappings: refactor decoding out of mapping decoding

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -1257,10 +1257,12 @@
           <emu-alg>
             1. For each Decoded Range Mapping Offset Record _rangeMappingOffset_ of _rangeMappingsOffsets_, do
               1. Let _mapping_ be the result of FindMappingForRangeMappingOffset(_mappings_, _rangeMappingOffset_).
-              1. If _mapping_ is ~not-found~, optionally report an error.
-              1. If _mapping_.[[OriginalPosition]] is *null*, optionally report an error.
-              1. Assert: _mapping_.[[IsRangeMapping]] is *false*.
-              1. Set _mapping_.[[IsRangeMapping]] to *true*.
+              1. If _mapping_ is ~not-found~, then
+                1. Optionally report an error.
+              1. Else,
+                1. If _mapping_.[[OriginalPosition]] is *null*, optionally report an error.
+                1. Assert: _mapping_.[[IsRangeMapping]] is *false*.
+                1. Set _mapping_.[[IsRangeMapping]] to *true*.
           </emu-alg>
         </emu-clause>
 


### PR DESCRIPTION
This PR addresses some feedback on #233, in particular to move the decoding out of regular mapping decoding.

This new PR's approach has all the range mapping decoding done after regular mapping decoding. Initially all mappings have a `[[IsRangeMapping]]` of false. If there are range mappings encoded, then the next decode step will update the field to true for any range mappings.

If a range mapping is specified for a mapping that doesn't map an original location, or the offset is out of range, then an error is optionally thrown.

One semantics question: should it also optionally throw if the mapping has a [[Name]] too?