### PR TITLE
Add alternative copyright

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -74,6 +74,8 @@
   shortname: ECMA-426
   status: draft
   location: https://tc39.es/ecma426/
+  boilerplate:
+    copyright: alternative
 </pre>
 <p><img src="img/ecma-logo.svg" id="ecma-logo" alt="Ecma International logo"></p>
 <div id="metadata-block">


### PR DESCRIPTION
TG4 and ECMA-426 were chartered and approved with the intention of using Ecma's Alternative Copyright, but the standards were published with the standard copyright. The secretariat will review, then distribute an ECMA-426 corrigendum to Ecma members ahead of a vote to approve at the next TC39 meeting.