### PR TITLE
Editorial: fix an argument of `StringSplit`

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -453,7 +453,7 @@
     <h1>
       StringSplit (
         _string_: a String,
-        _separators_: a List of String,
+        _separators_: a List of non-empty Strings,
       ): a List of Strings
     </h1>
     <dl class="header">


### PR DESCRIPTION
This PR adds a constraint on the `separators` argument in `StringSplit ( string, separators )`.

If `separators` contains an empty string, the algorithm may fail to terminate.

If in step 5.b `sep` is `""`, then `sepLen` is `0` and `candidate` is `substring(string, i, i)`, i.e., `""`. Assuming `matched` is `false` when this `sep` is considered, the condition in 5.b.iii will be true. In step 5.b.iii.4, `i := i + sepLen`, which is `i + 0`, and so `i` doesn't advance. In step 5.b.iii.5 `matched` becomes `true` and the true branch of step 5.c isn't executed, hence the loop condition `i < strLen` in step 5 remains true and the loop repeats with the same value of `i`.

This means that the algorithm does not terminate if there exists an iteration with `i < strLen` where an empty separator is considered and none of the _earlier_ separators matched at position `i`.