### PR TITLE
Scopes: Handle *null* for original variable names

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -1271,7 +1271,7 @@
             [[Definition]]: { ... }
             [[Bindings]]: [[
               {
-                [{From]]: { [[Line]]: 0, [[Column]]: 0 },
+                [[From]]: { [[Line]]: 0, [[Column]]: 0 },
                 [[Binding]]: "a",
               },
               {
@@ -1290,7 +1290,7 @@
       <ul>
         <li>[[Definition]] must not be *null*.</li>
         <li>[[Definition]].[[IsStackFrame]] must be *true*.</li>
-        <li>[[StackFrameType]] must be ~NONE~.</li>
+        <li>[[StackFrameType]] must be ~none~.</li>
       </ul>
 
       <emu-clause id="sec-binding-record-type">
@@ -1961,9 +1961,14 @@
             ScopeVariable : Vlq
           </emu-grammar>
           <emu-alg>
-            1. TODO: Handle *null* returned by RelativeName.
-            1. Return « RelativeName(|Vlq|, _accumulator_, _names_) ».
+            1. Let _variable_ be RelativeName(|Vlq|, _accumulator_, _names_).
+            1. If _variable_ is *null*, return « "" ».
+            1. Return _variable_.
           </emu-alg>
+
+          <emu-note>
+            |OriginalScopeVariables| preserves out-of-bounds indices with the empty string. Otherwise bindings cannot be matched to their respective variable.
+          </emu-note>
         </emu-clause>
 
         <emu-clause id="sec-RelativeName" type="abstract operation">

--- a/spec.emu
+++ b/spec.emu
@@ -1963,7 +1963,7 @@
           <emu-alg>
             1. Let _variable_ be RelativeName(|Vlq|, _accumulator_, _names_).
             1. If _variable_ is *null*, return « "" ».
-            1. Return _variable_.
+            1. Return « _variable_ ».
           </emu-alg>
 
           <emu-note>


### PR DESCRIPTION
This PR turns a broken `"names"` index into an empty string. We need to preserve the length of the array so bindings can be matched. We can't just filter out broken indices.

The alternatives are:
*  Type "Variables" in the original scope as `(string | null)[]` instead of just as `string[]`. This feels wrong though.
* Unconditionally report an error and abort decoding. This feels overly restrictive though.

Drive-by: FIx a typo and use `~none~` consistently.