### PR TITLE
Scopes: Add section that establishes relationship between Mappings and Scopes

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -2221,6 +2221,31 @@
         </emu-clause>
       </emu-clause>
     </emu-clause>
+
+    <emu-clause id="sec-mappings-relationship">
+      <h1>Relationship with mappings</h1>
+      <p>The Decoded Mapping Records of a Decoded Source Map Record must be consistent with respect to the Generated Range Records and Original Scope Records of the same Decoded Source Map Record. Informally, mappings and scopes information must not disagree on how they map from generated code to original code. Formally, for a Decoded Source Map Record _sourceMap_, the following steps must return *true*:</p>
+      <emu-alg>
+        1. For each Decoded Mapping Record _mapping_ of _sourceMap_.[[Mappings]], do
+          1. Let _originalPosition_ be _mapping_.[[OriginalPosition]].
+          1. If _originalPosition_ is not *null*, then
+            1. Let _range_ be the inner-most Generated Range Record of _sourceMap_.[[Ranges]] containing _mapping_.[[GeneratedPosition]].
+            1. If _range_ is not *null* and _range_.[[Definition]] is not *null*, then
+              1. Let _definition_ be _range_.[[Definition]].
+              1. Let _sourceScope_ be _originalPosition_.[[Source]].[[Scope]].
+              1. If _sourceScope_ is *null*, return *false*.
+              1. If _definition_ is not _sourceScope_ and _definition_ is not a descendant of _sourceScope_, return *false*.
+              1. If ComparePositions(_definition_.[[Start]], _originalPosition_) is ~greater~, return *false*.
+              1. If ComparePositions(_originalPosition_, _definition_.[[End]]) is not ~lesser~, return *false*.
+        1. Return *true*.
+      </emu-alg>
+      <emu-note>
+        TODO: Specify abstract operations for "inner-most Generated Range Record" and "IsDescendant".
+      </emu-note>
+      <emu-note>
+        The specification allows either the mapping or the generated range to be "unmapped", but if both map to original code, they need to do so consistently.
+      </emu-note>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-sources">

--- a/spec.emu
+++ b/spec.emu
@@ -711,7 +711,9 @@
         1. <ins>Let _sources_ be DecodeSourceMapSources(_baseURL_, _sourceRootField_, _sourcesField_, _sourcesContentField_, _ignoreListField_, _scopesAndRanges_.[[Scopes]]).</ins>
         1. Let _mappings_ be DecodeMappings(_mappingsField_, _namesField_, _sources_).
         1. [declared="a,b"] Sort _mappings_ in ascending order, with a Decoded Mapping Record _a_ being less than a Decoded Mapping Record _b_ if ComparePositions(_a_.[[GeneratedPosition]], _b_.[[GeneratedPosition]]) is ~lesser~.
-        1. <ins>Return the Decoded Source Map Record { [[File]]: _fileField_, [[Sources]]: _sources_, [[Mappings]]: _mappings_, [[Ranges]]: _scopesAndRanges_.[[Ranges]] }.</ins>
+        1. <ins>Let _sourceMap_ be the Decoded Source Map Record { [[File]]: _fileField_, [[Sources]]: _sources_, [[Mappings]]: _mappings_, [[Ranges]]: _scopesAndRanges_.[[Ranges]] }.</ins>
+        1. <ins>If MappingsConsistentWithScopes(_sourceMap_) is *false*, optionally report an error.</ins>
+        1. <ins>Return _sourceMap_.</ins>
       </emu-alg>
 
       <emu-clause id="sec-GetOptionalString" type="abstract operation">
@@ -2231,6 +2233,43 @@
           </emu-alg>
         </emu-clause>
       </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-mappings-relationship">
+      <h1>Relationship with mappings</h1>
+      <p>The Decoded Mapping Records of a Decoded Source Map Record must be consistent with respect to the Generated Range Records and Original Scope Records of the same Decoded Source Map Record. Informally, mappings and scopes information must not disagree on how they map from generated code to original code.</p>
+
+      <emu-clause id="op-mappings-consistent-with-scopes" type="abstract operation">
+        <h1>
+          MappingsConsistentWithScopes (
+            _sourceMap_: a Decoded Source Map Record,
+          ): a Boolean
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It returns *true*, iff the original position of any mapping lies within the definition scope of the inner-most range.</dd>
+        </dl>
+        <emu-alg>
+          1. For each Decoded Mapping Record _mapping_ of _sourceMap_.[[Mappings]], do
+            1. Let _originalPosition_ be _mapping_.[[OriginalPosition]].
+            1. If _originalPosition_ is not *null*, then
+              1. Let _range_ be the inner-most Generated Range Record of _sourceMap_.[[Ranges]] containing _mapping_.[[GeneratedPosition]].
+              1. If _range_ is not *null* and _range_.[[Definition]] is not *null*, then
+                1. Let _definition_ be _range_.[[Definition]].
+                1. Let _sourceRootScope_ be _originalPosition_.[[Source]].[[Scope]].
+                1. If _sourceRootScope_ is *null*, return *false*.
+                1. If _definition_ is not _sourceRootScope_ and _definition_ is not a descendant of _sourceRootScope_, return *false*.
+                1. If ComparePositions(_definition_.[[Start]], _originalPosition_) is ~greater~, return *false*.
+                1. If ComparePositions(_originalPosition_, _definition_.[[End]]) is not ~lesser~, return *false*.
+          1. Return *true*.
+        </emu-alg>
+      </emu-clause>
+      <emu-note>
+        TODO: Specify abstract operations for "inner-most Generated Range Record" and "IsDescendant".
+      </emu-note>
+      <emu-note>
+        The specification allows either the mapping or the generated range to be "unmapped", but if both map to original code, they need to do so consistently.
+      </emu-note>
     </emu-clause>
   </emu-clause>
 


### PR DESCRIPTION
## [Preview](https://tc39.es/ecma426/pr/245/#sec-mappings-relationship)

This is an outline how we could spec mappings <-> scopes relationship. The current proposal is that it's fine if either mappings or scopes (or both) don't map a position. But if they do, the mapping needs to point into the scope that corresponds to the generated range.