### PR TITLE
Fix signature of DecodeSourceMapSources

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -1134,7 +1134,7 @@
           _sources_: a List of either Strings or *null*,
           _sourcesContent_: a List of either Strings or *null*,
           _ignoreList_: a List of non-negative integers,
-        ): a Decoded Source Record
+        ): a List of Decoded Source Record
       </h1>
       <dl class="header"></dl>
       <emu-alg>

--- a/spec.emu
+++ b/spec.emu
@@ -1158,6 +1158,7 @@
           1. If _ignoreList_ contains _index_, set _decodedSource_.[[Ignored]] to *true*.
           1. If _sourcesContentCount_ > _index_, set _decodedSource_.[[Content]] to _sourcesContent_[_index_].
           1. Append _decodedSource_ to _decodedSources_.
+          1. Set _index_ to _index_ + 1.
         1. Return _decodedSources_.
       </emu-alg>
 

--- a/spec.emu
+++ b/spec.emu
@@ -1139,7 +1139,7 @@
       <dl class="header"></dl>
       <emu-alg>
         1. Let _decodedSources_ be a new empty List.
-        1. Let _sourcesContentCount_ be the the number of elements in _sourcesContent_.
+        1. Let _sourcesContentCount_ be the number of elements in _sourcesContent_.
         1. Let _sourceUrlPrefix_ be *""*.
         1. If _sourceRoot_ ≠ *null*, then
           1. If _sourceRoot_ ends with the code point U+002F (SOLIDUS), then


### PR DESCRIPTION
Inside the current signature of `DecodeSourceMapSources`, the returned value is specified as [Decoded Source Record](https://tc39.es/ecma426/#decoded-source-record), while the definition of the subroutine returns a list of the records: https://github.com/tc39/ecma426/blob/77bb6725d2adc64e2818f665d284b4d490405408/spec.emu#L1161