### PR TITLE
Meta: Bump ecmarkup to v24.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN https://tc39.es/ecma426/#sec-copyright-and-software-license",
       "devDependencies": {
         "@tc39/ecma262-biblio": "^2.2.3087",
-        "ecmarkup": "^24.1.0"
+        "ecmarkup": "^24.2.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -219,7 +219,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -243,7 +242,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -972,9 +970,9 @@
       }
     },
     "node_modules/ecmarkup": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-24.1.0.tgz",
-      "integrity": "sha512-mdS/6VB9WKdEOeR3SEMl6u1ML7T1A6dif+8q5XxSTK73F2JXjJwpY04FoM+a3w/S3acepb2cvFxB+0r3yIE0xg==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-24.2.0.tgz",
+      "integrity": "sha512-MMgmpm0p/MgjVSun8YDc5Fog7PXk55+cvR+4PjTCpHeeoPbUZjdUq//4YjF7Ek1N5S12HMiGBfDvkgtMBZDs+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "homepage": "https://tc39.es/ecma426/",
   "devDependencies": {
     "@tc39/ecma262-biblio": "^2.2.3087",
-    "ecmarkup": "^24.1.0"
+    "ecmarkup": "^24.2.0"
   }
 }


### PR DESCRIPTION
This should be done quickly for the localStorage schema migration of https://github.com/tc39/ecmarkup/pull/705 .